### PR TITLE
Import ContextTypes for handler contexts

### DIFF
--- a/src/bot/app.py
+++ b/src/bot/app.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import (
-    Application, CommandHandler, MessageHandler, filters, CallbackQueryHandler
+    Application, CommandHandler, MessageHandler, filters, CallbackQueryHandler, ContextTypes
 )
 
 from src.utils.html_sanitize import sanitize_html


### PR DESCRIPTION
## Summary
- import ContextTypes alongside Application and CommandHandler

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba9d4ca0348328b9679e52966b8fb3